### PR TITLE
add a function for track videofile in BaseTracker

### DIFF
--- a/pytracking/tracker/base/basetracker.py
+++ b/pytracking/tracker/base/basetracker.py
@@ -52,6 +52,59 @@ class BaseTracker:
 
         return tracked_bb, times
 
+    def track_videofile(self):
+        "Run track with a video file input."
+
+        cap = cv.VideoCapture("/home/dtt/Videos/haze/v_1509066461577.avi")
+        display_name = 'Display: ' + self.params.tracker_name
+        cv.namedWindow(display_name, cv.WINDOW_NORMAL | cv.WINDOW_KEEPRATIO)
+        cv.resizeWindow(display_name, 960, 720)
+
+        while True:
+            success, frame = cap.read()
+            if success is not True:
+                break
+            cv.imshow(display_name, frame)
+            k = cv.waitKey(100)
+            if k == 27:
+                x, y, w, h = cv.selectROI(display_name, frame)
+                init_state = [x, y, w, h]
+                self.initialize(frame, init_state)
+                break
+
+        if hasattr(self, 'initialize_features'):
+            self.initialize_features()
+
+        while True:
+            ret, frame = cap.read()
+            frame_disp = frame.copy()
+
+            # Draw box
+            state, flag= self.track(frame)
+            if(flag is not 'not_found'):
+                state = [int(s) for s in state]
+                cv.rectangle(frame_disp, (state[0], state[1]), (state[2] + state[0], state[3] + state[1]),
+                             (0, 255, 0), 5)
+            else:
+                print("target is disappeared.")
+
+            # Display the resulting frame
+            cv.imshow(display_name, frame_disp)
+            key = cv.waitKey(1)
+            if key == ord('q'):
+                break
+            elif key == ord('r'):
+                ret, frame = cap.read()
+                cv.imshow(display_name, frame)
+                x, y, w, h = cv.selectROI(display_name, frame)
+                init_state = [x, y, w, h]
+                self.initialize(frame, init_state)
+
+
+        # When everything done, release the capture
+        cap.release()
+        cv.destroyAllWindows()
+
 
     def track_webcam(self):
         """Run tracker with webcam."""
@@ -99,6 +152,7 @@ class BaseTracker:
         if hasattr(self, 'initialize_features'):
             self.initialize_features()
 
+
         while True:
             # Capture frame-by-frame
             ret, frame = cap.read()
@@ -113,7 +167,7 @@ class BaseTracker:
             if ui_control.mode == 'select':
                 cv.rectangle(frame_disp, ui_control.get_tl(), ui_control.get_br(), (255, 0, 0), 2)
             elif ui_control.mode == 'track':
-                state = self.track(frame)
+                state, flag = self.track(frame)
                 state = [int(s) for s in state]
                 cv.rectangle(frame_disp, (state[0], state[1]), (state[2] + state[0], state[3] + state[1]),
                              (0, 255, 0), 5)


### PR DESCRIPTION
add a function for track videofile in BaseTracker, as follow:

def track_videofile(self):
        "Run track with a video file input."

        cap = cv.VideoCapture("/home/dtt/Videos/haze/v_1509066461577.avi")
        display_name = 'Display: ' + self.params.tracker_name
        cv.namedWindow(display_name, cv.WINDOW_NORMAL | cv.WINDOW_KEEPRATIO)
        cv.resizeWindow(display_name, 960, 720)

        while True:
            success, frame = cap.read()
            if success is not True:
                break
            cv.imshow(display_name, frame)
            k = cv.waitKey(100)
            if k == 27:
                x, y, w, h = cv.selectROI(display_name, frame)
                init_state = [x, y, w, h]
                self.initialize(frame, init_state)
                break

        if hasattr(self, 'initialize_features'):
            self.initialize_features()

        while True:
            ret, frame = cap.read()
            frame_disp = frame.copy()

            # Draw box
            state, flag= self.track(frame)
            if(flag is not 'not_found'):
                state = [int(s) for s in state]
                cv.rectangle(frame_disp, (state[0], state[1]), (state[2] + state[0], state[3] + state[1]),
                             (0, 255, 0), 5)
            else:
                print("target is disappeared.")

            # Display the resulting frame
            cv.imshow(display_name, frame_disp)
            key = cv.waitKey(1)
            if key == ord('q'):
                break
            elif key == ord('r'):
                ret, frame = cap.read()
                cv.imshow(display_name, frame)
                x, y, w, h = cv.selectROI(display_name, frame)
                init_state = [x, y, w, h]
                self.initialize(frame, init_state)


        # When everything done, release the capture
        cap.release()
        cv.destroyAllWindows()