### PR TITLE
Fix url of ATOM Network

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,7 @@ mkdir pytracking/networks
 echo ""
 echo ""
 echo "****************** ATOM Network ******************"
-bash pytracking/utils/gdrive_download 1ZTdQbZ1tyN27UIwUnUrjHChQb5ug2sxr pytracking/networks/atom_default.pth
+bash pytracking/utils/gdrive_download 1JUB3EucZfBk3rX7M3_q5w_dLBqsT7s-M pytracking/networks/atom_default.pth
 
 echo ""
 echo ""


### PR DESCRIPTION
The URL of ATOM network is broken.
by #41, I could find new pth file from https://drive.google.com/drive/folders/1WVhJqvdu-_JG1U-V0IqfxTUa1SBPnL0O and change the original link to new link.