### PR TITLE
fix docstring

### DIFF
--- a/ltr/dataset/coco_seq.py
+++ b/ltr/dataset/coco_seq.py
@@ -23,8 +23,7 @@ class MSCOCOSeq(BaseDataset):
         - coco_root
             - annotations
                 - instances_train2014.json
-            - images
-                - train2014
+            - train2014
 
     Note: You also have to install the coco pythonAPI from https://github.com/cocodataset/cocoapi.
     """


### PR DESCRIPTION
The docstring contains the following description

    - coco_root
        - annotations
            - instances_train2014.json
        - images
            - train2014

Few lines later in the code, the following is used, rendering the docstring dataset structure description incorrect:

    self.img_pth = os.path.join(root, 'train2014/')
    self.anno_path = os.path.join(root, 'annotations/instances_train2014.json')
