### PR TITLE
Tiny fix on a dangling link on README.md

### DIFF
--- a/pytracking/README.md
+++ b/pytracking/README.md
@@ -61,7 +61,7 @@ The tookit consists of the following sub-modules.
  - [parameter](parameter): Contains the parameter settings for different trackers.  
  - [tracker](tracker): Contains the implementations of different trackers.  
  - [utils](utils): Some util functions. 
- - [VOT](vot): VOT Integration.  
+ - [VOT](VOT): VOT Integration.  
  
 ## Trackers
  The toolkit contains the implementation of the following trackers.  


### PR DESCRIPTION
If click the original link, GitHub will say 404 - https://github.com/visionml/pytracking/blob/master/pytracking/vot