### PR TITLE
Fix division bug of KYS

### DIFF
--- a/pytracking/libs/dcf.py
+++ b/pytracking/libs/dcf.py
@@ -25,7 +25,7 @@ def hann2d_clipped(sz: torch.Tensor, effective_sz: torch.Tensor, centered = True
     effective_sz += (effective_sz - sz) % 2
     effective_window = hann1d(effective_sz[0].item(), True).reshape(1, 1, -1, 1) * hann1d(effective_sz[1].item(), True).reshape(1, 1, 1, -1)
 
-    pad = (sz - effective_sz) / 2
+    pad = torch.floor_divide(sz - effective_sz, 2)
 
     window = F.pad(effective_window, (pad[1].item(), pad[1].item(), pad[0].item(), pad[0].item()), 'replicate')
 


### PR DESCRIPTION
From PyTorch 1.6, Integer division of tensors using / makes following error

"RuntimeError: Integer division of tensors using div or / is no longer supported, and in a future release div will perform true division as in Python 3. Use true_divide or floor_divide (// in Python) instead."

I've solved this error by changing it to floor_divide.

