### PR TITLE
Fix memory leak in LTRTrainer._update_stats().

### DIFF
--- a/ltr/trainers/ltr_trainer.py
+++ b/ltr/trainers/ltr_trainer.py
@@ -94,7 +94,7 @@ class LTRTrainer(BaseTrainer):
         for name, val in new_stats.items():
             if name not in self.stats[loader.name].keys():
                 self.stats[loader.name][name] = AverageMeter()
-            self.stats[loader.name][name].update(val, batch_size)
+            self.stats[loader.name][name].update(val.item(), batch_size)
 
     def _print_stats(self, i, loader, batch_size):
         self.num_frames += batch_size


### PR DESCRIPTION
The method `_update_stats()` is called with `val`, which is a `Tensor` with gradients. When use with `AverageMeter`, the gradient graph will be accumulated during training and won't be released and collected by GC, causing significant memory leak.
