### PR TITLE
Initialize tracker

### DIFF
--- a/pytracking/evaluation/tracker.py
+++ b/pytracking/evaluation/tracker.py
@@ -380,7 +380,12 @@ class Tracker:
                 init_state = ui_control.get_bb()
 
                 info['init_object_ids'] = [next_object_id, ]
+                info['object_ids'] = [next_object_id,]
+                info['sequence_object_ids'] = [next_object_id,]
                 info['init_bbox'] = OrderedDict({next_object_id: init_state})
+                out = tracker.initialize(frame, info)
+                prev_output = OrderedDict(out)
+
                 sequence_object_ids.append(next_object_id)
                 if save_results:
                     output_boxes[next_object_id] = [init_state, ]


### PR DESCRIPTION
In the current code, the tracker is not actually initialized if an optional_bbox is not passed in, or a reset is not called. This code changes that.

Without this change, the code crashes as soon as you define a bbox in the video.